### PR TITLE
Default args to `--width 80`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,9 +4,11 @@
     entry: format_markdown
     language: docker
     files: \.md$
+    args: ["--width", "80"]
 -   id: format-markdown-script
     name: format-markdown
     description: Format markdown files with cmark-gfm
     entry: format_markdown
     language: script
     files: \.md$
+    args: ["--width", "80"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0 - 2023-05-08
+
+### Change
+
+  - Add default args of: `--with 80`
+
 ## 0.2.0 - 2023-05-08
 
 ### Added


### PR DESCRIPTION
Since line width is one of the more inconsistent things when different people write markdown (the default for `cmark-gfm` is to not enforce a width)