### PR TITLE
Fix bad options in hooks config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,11 +4,11 @@
     entry: format_markdown
     language: docker
     files: \.md$
-    args: ["--width", "80", "--extensions", "table"]
+    args: ["--width", "80", "--extension", "table"]
 -   id: format-markdown-script
     name: format-markdown
     description: Format markdown files with cmark-gfm
     entry: format_markdown
     language: script
     files: \.md$
-    args: ["--width", "80", "--extensions", "table"]
+    args: ["--width", "80", "--extension", "table"]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,7 +7,10 @@ HERE="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 && pwd -P)"
 cp "$HERE/input.md" "$HERE/original.md"
 trap 'mv "$HERE/original.md" "$HERE/input.md"' EXIT
 
-"$HERE/../format_markdown" --width 80 "$HERE/input.md"
+"$HERE/../format_markdown" \
+    --width 80 \
+    --extension table \
+    "$HERE/input.md"
 
 if ! diff "$HERE/expected_output.md" "$HERE/input.md"
 then


### PR DESCRIPTION
Running as-is would result in an error:

    format_markdown: unrecognized option: extensions

So fix that, also update tests to run the same commands that pre-commit uses (would be nice if it were less manual to maintain the same value between the two)