### PR TITLE
Misc updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,9 @@
 name: tests
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 env:
   TAG: cmark-image

--- a/dockerfile
+++ b/dockerfile
@@ -6,9 +6,7 @@ RUN apk add --no-cache \
         cmake \
         gcc \
         g++ \
-        libc-dev \
-        # required for tests
-        python3 && \
+        libc-dev && \
     git clone \
         --quiet \
         --depth 1 \

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17 AS build
+FROM alpine:3.20 AS build
 
 RUN apk add --no-cache \
         git \
@@ -18,7 +18,7 @@ WORKDIR /app/build
 RUN cmake .. && \
     make -j
 
-FROM alpine:3.17 AS final
+FROM alpine:3.20 AS final
 
 COPY --from=build /app/build/src/cmark-gfm /usr/local/bin/cmark-gfm
 COPY --from=build /app/build/src/libcmark-gfm.so.* /usr/local/lib


### PR DESCRIPTION
- Drop `python3` build dependency

    This was only used for testing during builds, but we stopped doing that
    with b8641af5239ba953674e147b86547055222e60e6

- Bump alpine version

- Avoid running actions on any push

    I don't really want to run these unless I've actually created a PR (or
    it's a push to `main`)