### PR TITLE
V0.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,7 @@ repos:
     hooks:
     -   id: format-markdown-docker
         exclude: "tests/.*.md"
+-   repo: https://gitlab.com/matthewhughes/common-changelog
+    rev: v0.2.0
+    hooks:
+    -   id: validate-changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# Changelog
+
 ## 0.5.0 - 2023-05-08
 
-### Fix
+### Fixed
 
   - Fix typo in arg name
 
@@ -12,7 +14,7 @@
 
 ## 0.3.0 - 2023-05-08
 
-### Change
+### Changed
 
   - Add default args of: `--with 80`
 
@@ -30,4 +32,4 @@
 
 ## 0.1.0 - 2023-01-07
 
-  - Initial release
+*Initial release*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0 - 2025-04-20
+
+### Changed
+
+  - Drop `python3` as a build dependency
+  - Bump build image to Alpine 3.21
+  - Enforce common changelog
+
 ## 0.5.0 - 2023-05-08
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20 AS build
+FROM alpine:3.21 AS build
 
 RUN apk add --no-cache \
         git \
@@ -18,7 +18,7 @@ WORKDIR /app/build
 RUN cmake .. && \
     make -j
 
-FROM alpine:3.20 AS final
+FROM alpine:3.21 AS final
 
 COPY --from=build /app/build/src/cmark-gfm /usr/local/bin/cmark-gfm
 COPY --from=build /app/build/src/libcmark-gfm.so.* /usr/local/lib


### PR DESCRIPTION
- Bump Alpine to 3.21

- Enforce common changelog format

    Fix up the existing changelog and add a hook to enforce this moving
    forwards

- v0.6.0